### PR TITLE
Make the Inverter ABC(abstract base class)

### DIFF
--- a/server/inverters/SolarmanTCP.py
+++ b/server/inverters/SolarmanTCP.py
@@ -72,7 +72,7 @@ class SolarmanTCP(Inverter):
                             False, 
                             **kwargs)
 
-    # Template method
+    # Template method, override from superclass
     def _read_registers(self, operation, scan_start, scan_range):
         if operation != 0x04:
             resp = self.client.read_input_registers(self.get_address(), scan_start, scan_range)

--- a/server/inverters/inverter.py
+++ b/server/inverters/inverter.py
@@ -3,6 +3,8 @@ from pymodbus.pdu import ExceptionResponse
 from pymodbus import pymodbus_apply_logging_config
 from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 from .supported_inverters.profiles import InverterProfiles
+from abc import ABC, abstractmethod
+
 
 
 pymodbus_apply_logging_config("INFO")
@@ -11,7 +13,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
 
-class Inverter:
+class Inverter(ABC):
     """Base class for all inverters."""
 
     def __init__(self):
@@ -133,6 +135,7 @@ class Inverter:
         """
         return [x for x in range(scan_start, scan_start + scan_range, 1)]
 
+   
     def read_registers(self, operation, scan_start, scan_range):
         """
         Read a range of input registers from a start address
@@ -175,6 +178,7 @@ class Inverter:
             raise Exception("writeRegisters() - ExceptionResponse: " + str(resp))
         return resp
 
+    @abstractmethod
     def _read_registers(self, operation, scan_start, scan_range):
         if operation == 0x04:
             resp = self.client.read_input_registers(scan_start, scan_range, slave=self.get_address())

--- a/server/inverters/inverter.py
+++ b/server/inverters/inverter.py
@@ -3,7 +3,7 @@ from pymodbus.pdu import ExceptionResponse
 from pymodbus import pymodbus_apply_logging_config
 from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 from .supported_inverters.profiles import InverterProfiles
-from abc import ABC, abstractmethod
+from abc import ABC
 
 
 
@@ -178,7 +178,6 @@ class Inverter(ABC):
             raise Exception("writeRegisters() - ExceptionResponse: " + str(resp))
         return resp
 
-    @abstractmethod
     def _read_registers(self, operation, scan_start, scan_range):
         if operation == 0x04:
             resp = self.client.read_input_registers(scan_start, scan_range, slave=self.get_address())


### PR DESCRIPTION
Made Inverter class abstract and decorated _read_register to be an abstractmethod so it can be overridden in the subclasses and provide their own implementation.